### PR TITLE
fix: remove xformers for pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "torchvision",
     "tqdm",
     "transformers",
-    "xformers",
     "zarr",
     "pytorch-lightning>=2.1",
     "matplotlib",


### PR DESCRIPTION
to allow for pip install python 3.10